### PR TITLE
Update to compile on rust 1.28 stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,9 @@ version = "0.1.0"
 authors = ["tiehuis <marctiehuis@gmail.com>"]
 
 [dependencies]
-clippy = {version = "*", optional = true}
-time = "0.1.35"
-rand = "0.3"
-log = "0.3.6"
-itertools = "0.4"
-serde = "*"
-serde_json = "*"
-serde_macros = "*"
+rand = "0.5"
+itertools = "0.7"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
 
-[features]
-default = []

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -121,10 +121,10 @@ fn main() {
             for x in 0..engine.fd.width {
                 renderer.set_draw_color(match (engine.fd.occupies((x, y)), engine.bk.occupies((x, y)), ghost.occupies((x, y))) {
                     (true, true,  _)      => Color::RGB(255, 0, 0),
-                    (true, false, _)      => COLORMAP[engine.fd.get((x, y)).to_usize()],
-                    (false, true, _)      => COLORMAP[engine.bk.id.to_usize()],
+                    (true, false, _)      => COLORMAP[engine.fd.get((x, y)) as usize],
+                    (false, true, _)      => COLORMAP[engine.bk.id as usize],
                     (false, false, true)  => {
-                        let (r, g, b) = COLORMAP[engine.bk.id.to_usize()].rgb();
+                        let (r, g, b) = COLORMAP[engine.bk.id as usize].rgb();
                         Color::RGBA(20 + r / 7, 20 + g / 7, 20 + b / 7, 50)
                     },
                     (false, false, false) => Color::RGB(0, 0, 0)
@@ -145,7 +145,7 @@ fn main() {
 
         // Draw preview pieces
         for id in engine.rd.preview(3) { //engine.op.preview_count as usize) {
-            renderer.set_draw_color(COLORMAP[id.to_usize()]);
+            renderer.set_draw_color(COLORMAP[id as usize]);
             for &(x, y) in engine.bk.rs.data(id, Rotation::R0) {
                 let _ = renderer.fill_rect(sq!(xoffset + 15 * x as u32, yoffset + 15 * y as u32, 15));
             }
@@ -154,7 +154,7 @@ fn main() {
 
         // Draw hold piece
         if engine.hd.is_some() {
-            renderer.set_draw_color(COLORMAP[engine.hd.unwrap().to_usize()]);
+            renderer.set_draw_color(COLORMAP[engine.hd.unwrap() as usize]);
             for &(x, y) in engine.bk.rs.data(engine.hd.unwrap(), Rotation::R0) {
                 let _ = renderer.fill_rect(sq!(LEFT_FIELD_POSITION - 15 * 4 - 20 + 15 * x as u32, UPPER_MARGIN2 + 15 * y as u32, 15));
             }

--- a/src/block.rs
+++ b/src/block.rs
@@ -22,7 +22,6 @@ use field::Field;
 use rotation_system::{self, RotationSystem};
 
 use std::mem;
-use collections::enum_set::CLike;
 
 /// The identifier for a particular `Block`.
 #[repr(usize)]
@@ -32,19 +31,15 @@ pub enum Id {
     I, T, L, J, S, Z, O, None
 }
 
-impl CLike for Id {
-    fn to_usize(&self) -> usize {
-        *self as usize
-    }
-
-    fn from_usize(v: usize) -> Id {
-        assert!(v < 7);
-        unsafe { mem::transmute(v) }
-    }
+impl From<usize> for Id {
+	fn from(t: usize) -> Self {
+		assert!(t < 7);
+		unsafe { mem::transmute(t) }
+	}
 }
 
 impl Id {
-    /// Returns all `Id` variants known.
+	/// Returns all `Id` variants known.
     ///
     /// This does not return the `None` variant.
     pub fn variants() -> &'static [Id] {
@@ -83,31 +78,27 @@ pub enum Rotation {
 
 impl Default for Rotation { fn default() -> Rotation { Rotation::R0 } }
 
-impl CLike for Rotation {
-    fn to_usize(&self) -> usize {
-        *self as usize
-    }
-
-    fn from_usize(v: usize) -> Rotation {
-        assert!(v < 4);
-        unsafe { mem::transmute(v) }
-    }
+impl From<usize> for Rotation {
+	fn from(t: usize) -> Self {
+		assert!(t < 4);
+		unsafe { mem::transmute(t) }
+	}
 }
 
 impl Rotation {
-    /// Returns all known `Rotation` variants.
+	/// Returns all known `Rotation` variants.
     pub fn variants() -> Vec<Rotation> {
         vec![Rotation::R0, Rotation::R90, Rotation::R180, Rotation::R270]
     }
 
     /// Returns the next clockwise rotation.
     pub fn clockwise(&self) -> Rotation {
-        Rotation::from_usize((self.to_usize() + 4 + 1) % 4)
+        Rotation::from((*self as usize + 4 + 1) % 4)
     }
 
     /// Returns the next anticlockwise rotation.
     pub fn anticlockwise(&self) -> Rotation {
-        Rotation::from_usize((self.to_usize() + 4 - 1) % 4)
+        Rotation::from((*self as usize + 4 - 1) % 4)
     }
 }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -8,7 +8,6 @@
 //! call to the `deactivate` function.
 
 use std::mem;
-use collections::enum_set::CLike;
 
 /// 'Controller Time' array.
 ///
@@ -30,14 +29,11 @@ pub enum Action {
     RotateLeft, RotateRight, Hold, Quit
 }
 
-impl CLike for Action {
-    fn to_usize(&self) -> usize {
-        *self as usize
-    }
-
-    fn from_usize(v: usize) -> Action {
-        unsafe { mem::transmute(v) }
-    }
+impl From<usize> for Action {
+	fn from(t: usize) -> Self {
+		assert!(t < 8);
+		unsafe { mem::transmute(t) }
+	}
 }
 
 /// A controller stores the internal state as a series of known actions.
@@ -65,12 +61,12 @@ impl Controller {
 
     /// Query if an action is currently active.
     pub fn active(&self, action: Action) -> bool {
-        self.active[action.to_usize()]
+        self.active[action as usize]
     }
 
     /// Query how long an action has been active for.
     pub fn time(&self, action: Action) -> u64 {
-        self.time[action.to_usize()]
+        self.time[action as usize]
     }
 
     /// Activate the specified action.
@@ -78,7 +74,7 @@ impl Controller {
     /// The action will be set to active.
     /// Activating an already active timer has no effect.
     pub fn activate(&mut self, action: Action) {
-        self.active[action.to_usize()] = true;
+        self.active[action as usize] = true;
     }
 
     /// Deactivate the specified action.
@@ -86,7 +82,7 @@ impl Controller {
     /// The action will be set to inactive.
     /// Deactivating an already inactive action has no effect.
     pub fn deactivate(&mut self, action: Action) {
-        self.active[action.to_usize()] = false;
+        self.active[action as usize] = false;
     }
 
     /// Deactivate all actions.
@@ -130,31 +126,30 @@ impl Controller {
 mod tests {
 
     use super::*;
-    use collections::enum_set::CLike;
 
     #[test]
     fn test() {
         let mut controller = Controller::new();
 
         controller.activate(Action::MoveLeft);
-        assert_eq!(controller.active[Action::MoveLeft.to_usize()], true);
-        assert_eq!(controller.time[Action::MoveLeft.to_usize()], 0);
+        assert_eq!(controller.active[Action::MoveLeft as usize], true);
+        assert_eq!(controller.time[Action::MoveLeft as usize], 0);
 
         controller.update();
-        assert_eq!(controller.time[Action::MoveLeft.to_usize()], 1);
+        assert_eq!(controller.time[Action::MoveLeft as usize], 1);
 
         controller.deactivate(Action::MoveLeft);
-        assert_eq!(controller.time[Action::MoveLeft.to_usize()], 1);
+        assert_eq!(controller.time[Action::MoveLeft as usize], 1);
 
         controller.update();
-        assert_eq!(controller.time[Action::MoveLeft.to_usize()], 0);
+        assert_eq!(controller.time[Action::MoveLeft as usize], 0);
 
         controller.activate(Action::MoveLeft);
         controller.activate(Action::MoveRight);
         controller.update();
         controller.update();
         controller.update();
-        assert_eq!(controller.time[Action::MoveLeft.to_usize()], 3);
-        assert_eq!(controller.time[Action::MoveRight.to_usize()], 3);
+        assert_eq!(controller.time[Action::MoveLeft as usize], 3);
+        assert_eq!(controller.time[Action::MoveRight as usize], 3);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -12,7 +12,6 @@
 //
 // (omitted real IRS and IHS handling)
 
-use collections::enum_set::CLike;
 use std::fs::File;
 use std::io::Read;
 use serde_json;
@@ -243,7 +242,7 @@ impl Engine {
     /// Check if a particular action has been pressed with the specified
     /// rate.
     fn is_pressed(&self, action: Action, rate: u64) -> bool {
-        let sct = self.co.time[action.to_usize()] as u64;
+        let sct = self.co.time[action as usize] as u64;
         let das = self.ticks(self.op.das);
 
         // First press, or over das and arr rate has fired

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,7 +1,6 @@
 //! Module which provides history management tools.
 
 use controller::{Action, Controller, CAarray};
-use collections::enum_set::CLike;
 
 /// An individual event in a history sequence.
 #[allow(dead_code)]
@@ -54,14 +53,14 @@ impl History {
                     self.history.push(Event {
                         press: false,
                         ticks: self.tick_count,
-                        action: Action::from_usize(i)
+                        action: Action::from(i)
                     });
                 },
                 (false, true) => {
                     self.history.push(Event {
                         press: true,
                         ticks: self.tick_count,
-                        action: Action::from_usize(i)
+                        action: Action::from(i)
                     });
                 },
                 _ => ()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,3 @@
-#![feature(collections, enumset)]
-#![feature(custom_derive, plugin)]
-#![plugin(serde_macros)]
-
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-
 #![warn(missing_docs)]
 
 #![crate_name = "tetrs"]
@@ -34,12 +27,11 @@
 //! block.shift_extend(&field, Direction::Down);
 //! ```
 
+extern crate serde;
 extern crate serde_json;
-extern crate collections;
+#[macro_use] extern crate serde_derive;
 #[macro_use] extern crate itertools;
 extern crate rand;
-extern crate time;
-#[macro_use] extern crate log;
 
 /// Perform a safe conversion to i32, panicing if the current type does not
 /// lie within the required bounds.

--- a/src/rotation_system/mod.rs
+++ b/src/rotation_system/mod.rs
@@ -128,7 +128,6 @@ pub trait RotationSystem {
 /// This could work as a derive attribute probably, but that is extra work.
 macro_rules! rs_gen {
     ($id:ident) => {
-        use collections::enum_set::CLike;
         use block::{Id, Rotation};
         use rotation_system::RotationSystem;
 
@@ -148,13 +147,13 @@ macro_rules! rs_gen {
         impl RotationSystem for $id {
             fn data(&self, ty: Id, rotation: Rotation) -> &'static [(usize, usize)] {
                 match ty {
-                    Id::I => &I[rotation.to_usize()],
-                    Id::T => &T[rotation.to_usize()],
-                    Id::L => &L[rotation.to_usize()],
-                    Id::J => &J[rotation.to_usize()],
-                    Id::S => &S[rotation.to_usize()],
-                    Id::Z => &Z[rotation.to_usize()],
-                    Id::O => &O[rotation.to_usize()],
+                    Id::I => &I[rotation as usize],
+                    Id::T => &T[rotation as usize],
+                    Id::L => &L[rotation as usize],
+                    Id::J => &J[rotation as usize],
+                    Id::S => &S[rotation as usize],
+                    Id::Z => &Z[rotation as usize],
+                    Id::O => &O[rotation as usize],
                     _ => panic!("Attempted to get data for Id: {:?}", ty)
                 }
             }

--- a/src/wallkick/srs.rs
+++ b/src/wallkick/srs.rs
@@ -7,7 +7,6 @@
 use block::{self, Rotation, Block};
 use field::Field;
 use wallkick::Wallkick;
-use collections::enum_set::CLike;
 
 gen_wallkick!(SRS);
 
@@ -22,18 +21,18 @@ impl Wallkick for SRS {
             match r {
                 Rotation::R90 => {
                     if block.id == block::Id::I {
-                        &RIGHT_I[block.r.to_usize()]
+                        &RIGHT_I[block.r as usize]
                     }
                     else {
-                        &RIGHT_JLSTZ[block.r.to_usize()]
+                        &RIGHT_JLSTZ[block.r as usize]
                     }
                 },
                 Rotation::R270 => {
                     if block.id == block::Id::I {
-                        &LEFT_I[block.r.to_usize()]
+                        &LEFT_I[block.r as usize]
                     }
                     else {
-                        &LEFT_JLSTZ[block.r.to_usize()]
+                        &LEFT_JLSTZ[block.r as usize]
                     }
                 },
                 _ => panic!("Invalid wallkick test")


### PR DESCRIPTION
Hi, I just made some minor changes to get it to compile on current rust stable.

Remove some dependencies (clippy, time, serde_macros, log)
Update other dependencies (itertools, rand, serde)
Get rid of use of enum_set module in favor of casting enums to usize and transmuting usizes to enums in From<usize> impls